### PR TITLE
Use = instead of +=

### DIFF
--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -221,7 +221,7 @@ Header()
     GITHUB_URL="https://api.github.com"
     GRAPHQL_URL="https://api.github.com/graphql"
   else
-    GITHUB_URL+="${GHE_URL}/api/v3"
+    GITHUB_URL="${GHE_URL}/api/v3"
     GRAPHQL_URL="${GHE_URL}/api/graphql"
   fi
 


### PR DESCRIPTION
It looks like this might be a mistake, because `+=` is used to append data, but this looks to be the first usage of `GITHUB_URL`. I could be wrong, though?
