### PR TITLE
fix: add PR `number` for paged pull requests

### DIFF
--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -1149,7 +1149,7 @@ GetNextReviews() {
   {
   cat <<EOF
     {
-  "query":"{ repository(owner:\"${OWNER}\" name:\"${REPO_NAME}\") { owner { login } name pullRequest(number:${PR_NUMBER}) { commits(first:1){  totalCount   }    timeline(first: 1) {  totalCount    }    comments(first: 1) {  totalCount    }    reviews(first: ${EXTRA_PAGE_SIZE}${REVIEW_NEXT_PAGE}) { totalCount pageInfo { hasNextPage endCursor } nodes { comments(first: 1) {    totalCount } } } } }}"
+  "query":"{ repository(owner:\"${OWNER}\" name:\"${REPO_NAME}\") { owner { login } name pullRequest(number:${PR_NUMBER}) { number  commits(first:1){  totalCount   }    timeline(first: 1) {  totalCount    }    comments(first: 1) {  totalCount    }    reviews(first: ${EXTRA_PAGE_SIZE}${REVIEW_NEXT_PAGE}) { totalCount pageInfo { hasNextPage endCursor } nodes { comments(first: 1) {    totalCount } } } } }}"
     }
 EOF
   }


### PR DESCRIPTION
We found that when a PR has a large number of reviews, that the processing of
the pull request will fail because it finds the PR number to be null (see [line
994](https://github.com/mona-actions/gh-repo-stats/blob/4e01afc7d05671237ee1c87f173186028ccd1073/gh-repo-stats#L994)). This is because the PR number is not included in the request for
subsequent pages.

Here's an example output run where we had an issue. You can see `number` is not requested.

```bash
21:26:59  Analyzing Pull Request Reviews for: mui PR: 7745
21:27:00  More pages of reviews. Gathering next batch.
21:27:00  Getting pull request reviews
21:27:00  curl -kw '%{http_code}' -s -X POST -H "authorization: Bearer ****" -H "content-type: application/json"   --data "    {
21:27:00    "query":"{ repository(owner:\"metasys\" name:\"mui\") { owner { login } name pullRequest(number:7745) { commits(first:1){  totalCount   }    timeline(first: 1) {  totalCount    }    comments(first: 1) {  totalCount    }    reviews(first: 100, after: \"Y3Vyc29yOnYyOpO5MjAxOS0wOC0wMlQwOTo1ODoyNC0wNTowMLkyMDE5LTA4LTAyVDA5OjU4OjIzLTA1OjAwzgACvo4=\") { totalCount pageInfo { hasNextPage endCursor } nodes { comments(first: 1) {    totalCount } } } } }}"

... and later

21:27:01  Analyzing Pull Request Reviews for: mui PR: null
21:27:03  More pages of reviews. Gathering next batch.
21:27:03  Getting pull request reviews
21:27:03  curl -kw '%{http_code}' -s -X POST -H "authorization: Bearer ****" -H "content-type: application/json"   --data "    {
21:27:03    "query":"{ repository(owner:\"metasys\" name:\"mui\") { owner { login } name pullRequest(number:null) { commits(first:1){  totalCount   }    timeline(first: 1) {  totalCount    }    comments(first: 1) {  totalCount    }    reviews(first: 100, after: \"Y3Vyc29yOnYyOpO5MjAxOS0wOC0wMlQxMDowMzozNy0wNTowMLkyMDE5LTA4LTAyVDEwOjAzOjM3LTA1OjAwzgACvvM=\") { totalCount pageInfo { hasNextPage endCursor } nodes { comments(first: 1) {    totalCount } } } } }}"
21:27:03      }"   "https://github.jci.com/api/graphql"
21:27:03  REVIEW DATA BLOCK:
21:27:03  {
21:27:03    "errors": [
21:27:03      {
21:27:03        "path": [
21:27:03          "query",
21:27:03          "repository",
21:27:03          "pullRequest",
21:27:03          "number"
21:27:03        ],
21:27:03        "extensions": {
21:27:03          "code": "argumentLiteralsIncompatible",
21:27:03          "typeName": "Field",
21:27:03          "argumentName": "number"
21:27:03        },
21:27:03        "locations": [
21:27:03          {
21:27:03            "line": 1,
21:27:03            "column": 65
21:27:03          }
21:27:03        ],
21:27:03        "message": "Argument 'number' on Field 'pullRequest' has an invalid value (null). Expected type 'Int!'."
21:27:03      }
21:27:03    ]
21:27:03  }
```