### PR TITLE
fix: fix math with timeline and commit counts of a PR

### DIFF
--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -1002,7 +1002,25 @@ AnalyzePullRequests() {
       AnalyzeReviews "${PR}"
     fi
 
-    ISSUE_EVENT_CT=$((ISSUE_EVENT_CT + EVENT_CT - COMMENT_CT - COMMIT_CT))
+    # TODO: Is there a possible issue with .timeline.totalCount not including all comments either?
+    if [[ ${COMMIT_CT} -gt 250 ]]; then
+      REDUNDANT_EVENT_CT=$((COMMENT_CT + 250))
+    else
+      REDUNDANT_EVENT_CT=$((COMMENT_CT + COMMIT_CT))
+    fi
+
+    if [[ ${REDUNDANT_EVENT_CT} -gt ${EVENT_CT} ]]; then
+        echo ""
+        echo "######################################################"
+        echo "WARNING! There are more redundant events than timeline events for PR ${PR_NUMBER}!"
+        echo "gh-repo-stats may have an issue"
+        echo "EVENT_CT: ${EVENT_CT}"
+        echo "COMMENT_CT: ${COMMENT_CT}"
+        echo "COMMIT_CT: ${COMMIT_CT}"
+        echo "######################################################"
+    fi
+
+    ISSUE_EVENT_CT=$((ISSUE_EVENT_CT + EVENT_CT - REDUNDANT_EVENT_CT))
     ISSUE_COMMENT_CT=$((ISSUE_COMMENT_CT + COMMENT_CT))
     PR_REVIEW_CT=$((PR_REVIEW_CT + REVIEW_CT))
   done


### PR DESCRIPTION
From our Enterprise Server at 3.4.2, we found cases where a pull request has
more than 250 commits. It seems like the timeline count doesn't incorporate the
full commit count, so the subtraction of commit count from the timeline count
would result in a negative total record count.

This commit changes the math of the issue event count so that only 250 commits
are subtracted from the timeline count if the commit count is greater than 250.
This logic and behavior of the timeline GraphQL property needs to be confirmed
by a GitHub engineer.

NOTE: Similar changes may need to be made with respect to the comment count of
a pull request as well. I just haven't found a use case to test it myself.

I'm leaving this in a draft state at the moment, because I'm not sure if this
accurate or not. @admiralAwkbar - this is what I emailed you about and a
potential fix.