### PR TITLE
JQ Prerequisite Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ When the extension is run to completion, you will be presented with a visual tab
 
 ## Prerequisites
 
-- **GitHub CLI** installed by following this documentation: <https://github.com/cli/cli#installation>
 - Operating system that can run shell scripts(*bash/sh*)
+- **GitHub CLI** installed by following this documentation: <https://github.com/cli/cli#installation>
+- **jq** command line JSON parser package: <https://stedolan.github.io/jq/>
 
 You need to either export these environment variables:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ When the extension is run to completion, you will be presented with a visual tab
 
 - Operating system that can run shell scripts(*bash/sh*)
 - **GitHub CLI** installed by following this documentation: <https://github.com/cli/cli#installation>
-- **jq** command line JSON parser package: <https://stedolan.github.io/jq/>
+- **jq** command-line JSON parser: <https://stedolan.github.io/jq/>
 
 You need to either export these environment variables:
 

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -207,8 +207,9 @@ Header() {
   ############################
   # Validate prereq packages #
   ############################
-  jq > /dev/null 2>&1
-  if [[ $? -ne 0 ]]; then
+ 
+  # if the exit code from trying to execute jq is non-zero, then it is not installed
+  if [[ jq ]]; then
     echo "JQ (command-line JSON parser) is not installed. See https://stedolan.github.io/jq"
     exit 1;
   fi

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -204,6 +204,15 @@ Header() {
   GHE_URL_NO_WHITESPACE="$(echo -e "${GHE_URL}" | tr -d '[:space:]')"
   GHE_URL=$GHE_URL_NO_WHITESPACE
 
+  ############################
+  # Validate prereq packages #
+  ############################
+  jq > /dev/null 2>&1
+  if [[ $? -ne 0 ]]; then
+    echo "JQ (command-line JSON parser) is not installed. See https://stedolan.github.io/jq"
+    exit 1;
+  fi
+
   #################################
   # Get the Personal Access Token #
   #################################

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -204,16 +204,6 @@ Header() {
   GHE_URL_NO_WHITESPACE="$(echo -e "${GHE_URL}" | tr -d '[:space:]')"
   GHE_URL=$GHE_URL_NO_WHITESPACE
 
-  ############################
-  # Validate prereq packages #
-  ############################
- 
-  # if the exit code from trying to execute jq is non-zero, then it is not installed
-  if [[ jq ]]; then
-    echo "JQ (command-line JSON parser) is not installed. See https://stedolan.github.io/jq"
-    exit 1;
-  fi
-
   #################################
   # Get the Personal Access Token #
   #################################


### PR DESCRIPTION
Currently, JQ (https://stedolan.github.io/jq/) is a requirement for this script to run, however we perform no validation for it, and do not mention it in the README. This is an attempt to mitigate that for future users.