### PR TITLE
Fix Incorrect Parameter Case

### DIFF
--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -97,7 +97,7 @@ while (( "$#" )); do
       GHE_URL=$2
       shift 2
       ;;
-    -d|--DEBUG)
+    -d|--debug)
       DEBUG=true
       shift
       ;;


### PR DESCRIPTION
The documentation says `-d` or `--debug`, but the code is either `-d` or `--DEBUG`.

Changing case of code to be lower to match all the other parameters, rather than updating the documentation.