### PR TITLE
Add Version Detection & Support 2.21.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 This information outlines the underlying **GitHub** `metadata` associated with your repository. This information is key to understanding how long a migration of the data from one instance of **GitHub** to another will take.
 When the extension is run to completion, you will be presented with a visual table, or `*.csv` file to parse for all relevant information.
 
+## GHES Compatibility
+The __gh-repo-stats__ extension supports the following versions of GitHub Enterpise Server (GHES):
+
+- Supported: >= 2.20
+- Not Supported: <= v2.19
+
+_It should be noted that support for versions < 3.1 is limited._
+
 ## Prerequisites
 
-- Operating system that can run shell scripts(*bash/sh*)
+- Operating system that can run shell scripts (*bash/sh*)
 - **GitHub CLI** installed by following this documentation: <https://github.com/cli/cli#installation>
 - **jq** command-line JSON parser: <https://stedolan.github.io/jq/>
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ This information outlines the underlying **GitHub** `metadata` associated with y
 When the extension is run to completion, you will be presented with a visual table, or `*.csv` file to parse for all relevant information.
 
 ## GHES Compatibility
-The __gh-repo-stats__ extension supports the following versions of GitHub Enterpise Server (GHES):
+The **gh-repo-stats** extension supports the following versions of GitHub Enterpise Server (GHES):
 
 - Supported: >= 2.20
 - Not Supported: <= v2.19
 
-_It should be noted that support for versions < 3.1 is limited._
+*It should be noted that support for versions < 3.1 is limited.*
 
 ## Prerequisites
 

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -269,7 +269,7 @@ Header() {
   #####################
   # Check GHE version #
   #####################
-  if [[ "${GITHUB_URL}" != "https://api.github.com" ]]; then
+  if [[ ! isCloud ]]; then
 
     META_RESPONSE=$(curl -kw '%{http_code}' -s --request GET \
     --url "${GITHUB_URL}"/meta \
@@ -292,15 +292,21 @@ Header() {
     else
       VERSION=$(echo "${META_DATA}" | jq -r '.installed_version')
 
-
       # Get major/minor versions
       VERSION_MAJOR=$(echo "${VERSION}" | cut -d "." -f 1);
       VERSION_MINOR=$(echo "${VERSION}" | cut -d "." -f 2);
+
+      # Validate supported versions
+      if [[ "$(isCompatibleGHESVersion)" -eq "0" ]]; then
+        echo "GitHub Enterprise version ${VERSION} is not supported."
+        exit 1;
+      fi
     fi
   else
     VERSION="cloud"
   fi
   Debug "Version: ${VERSION}"
+
 
   ###########################
   # Check org or input file #
@@ -494,8 +500,14 @@ GenerateFiles() {
     # Create Header in the file #
     #############################
     echo "Creating file header..."
+
+    IS_EMPTY_HEADER="Is_Empty,";
+    if [[ "$(isCompatibleGHESVersion)" -eq "2" ]]; then
+      IS_EMPTY_HEADER="";
+    fi
+
     # File format headers: ORG_NAME,REPO_NAME,IS_EMPTY,PUSHED_AT,UPDATED_AT,IS_FORK,REPO_SIZE,RECORD_CT,COLLABORATOR_CT,PROTECTED_BRANCH_CT,PR_REVIEW_CT,MILESTONE_CT,ISSUE_CT,PR_CT,PR_REVIEW_COMMENT_CT,COMMIT_COMMENT_CT,ISSUE_COMMENT_CT,ISSUE_EVENT_CT,RELEASE_CT,PROJECT_CT,GHE_URL/ORG_NAME/REPO_NAME,MIGRATION_ISSUE
-    echo "Org_Name,Repo_Name,Is_Empty,Last_Push,Last_Update,isFork,Repo_Size(mb),Record_Count,Collaborator_Count,Protected_Branch_Count,PR_Review_Count,Milestone_Count,Issue_Count,PR_Count,PR_Review_Comment_Count,Commit_Comment_Count,Issue_Comment_Count,Issue_Event_Count,Release_Count,Project_Count,Full_URL,Migration_Issue" >> "${OUTPUT_FILE_NAME}" 2>&1
+    echo "Org_Name,Repo_Name,${IS_EMPTY_HEADER}Last_Push,Last_Update,isFork,Repo_Size(mb),Record_Count,Collaborator_Count,Protected_Branch_Count,PR_Review_Count,Milestone_Count,Issue_Count,PR_Count,PR_Review_Comment_Count,Commit_Comment_Count,Issue_Comment_Count,Issue_Event_Count,Release_Count,Project_Count,Full_URL,Migration_Issue" >> "${OUTPUT_FILE_NAME}" 2>&1
 
     #######################
     # Load the error code #
@@ -554,16 +566,25 @@ CheckAdminRights() {
   fi
 }
 ################################################################################
-#### Function CheckVersionCompatibility ########################################
-CheckVersionCompatibility() {
-  if [[ "${VERSION_MAJOR}" -lt "3" ]]; then
+#### Function isGHEC ###########################################################
+isCloud() {
+  if [[ "${GITHUB_URL}" != "https://api.github.com" ]]; then
+    echo 0;
+  else
+    echo 1;
+  fi
+}
+################################################################################
+#### Function isIncompatibleGHESVersion ########################################
+isCompatibleGHESVersion() {
+  if [[ ! isCloud ]] && [[ "${VERSION_MAJOR}" -lt "3" ]]; then
     if  [[ "${VERSION_MAJOR}" -eq "2" ]] && [[ "${VERSION_MINOR}" -gt "21" ]]; then
-      echo 0;
+      echo 2;
     else
-      echo 1;
+      echo 0;
     fi
   else
-    echo 0;
+    echo 1;
   fi
 }
 ################################################################################
@@ -654,8 +675,9 @@ GetRepos() {
   ##############################
   function generate_graphql_data()
   {
+    # When the version is 2.21, we need to remove the isEmpty flag
     IS_EMPTY_FLAG="isEmpty";
-    if [[ "${VERSION_MAJOR}" -lt "3" ]] && [[ "${VERSION_MAJOR}" -lt "22" ]]; then
+    if [[ "$(isCompatibleGHESVersion)" -eq "2" ]]; then
       IS_EMPTY_FLAG="";
     fi
     cat <<EOF
@@ -781,7 +803,12 @@ ParseRepoData() {
       REPO_SIZE_KB=$(_jq '.diskUsage')
       REPO_SIZE=$(ConvertKBToMB "${REPO_SIZE_KB}")
 
-      IS_EMPTY=$(_jq '.isEmpty')
+      # Look for isEmpty property only if it's supported
+      IS_EMPTY="";
+      if [[ "$(isCompatibleGHESVersion)" -eq "1" ]]; then
+        IS_EMPTY="$(_jq '.isEmpty'),"
+      fi
+
       PUSHED_AT=$(_jq '.pushedAt')
       UPDATED_AT=$(_jq '.updatedAt')
       IS_FORK=$(_jq '.isFork')
@@ -836,7 +863,7 @@ ParseRepoData() {
       ########################
       # Write it to the file #
       ########################
-      echo "${ORG_NAME},${REPO_NAME},${IS_EMPTY},${PUSHED_AT},${UPDATED_AT},${IS_FORK},${REPO_SIZE},${RECORD_CT},${COLLABORATOR_CT},${PROTECTED_BRANCH_CT},${PR_REVIEW_CT},${MILESTONE_CT},${ISSUE_CT},${PR_CT},${PR_REVIEW_COMMENT_CT},${COMMIT_COMMENT_CT},${ISSUE_COMMENT_CT},${ISSUE_EVENT_CT},${RELEASE_CT},${PROJECT_CT},${GHE_URL}/${ORG_NAME}/${REPO_NAME},${MIGRATION_ISSUE}" >> "${OUTPUT_FILE_NAME}"
+      echo "${ORG_NAME},${REPO_NAME},${IS_EMPTY}${PUSHED_AT},${UPDATED_AT},${IS_FORK},${REPO_SIZE},${RECORD_CT},${COLLABORATOR_CT},${PROTECTED_BRANCH_CT},${PR_REVIEW_CT},${MILESTONE_CT},${ISSUE_CT},${PR_CT},${PR_REVIEW_COMMENT_CT},${COMMIT_COMMENT_CT},${ISSUE_COMMENT_CT},${ISSUE_EVENT_CT},${RELEASE_CT},${PROJECT_CT},${GHE_URL}/${ORG_NAME}/${REPO_NAME},${MIGRATION_ISSUE}" >> "${OUTPUT_FILE_NAME}"
 
       #######################
       # Load the error code #

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -635,10 +635,22 @@ CheckAPILimit() {
   ##############################################################
   # Check what is remaining, and if 0, we need to sleep it off #
   ##############################################################
-  API_REMAINING_CMD=$(curl -s -X GET \
+  API_REMAINING_REQUEST=$(curl -s -X GET \
     --url "${GITHUB_URL}/rate_limit" \
-    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-    |  jq -r '.resources.graphql.remaining' 2>&1)
+    -H "Authorization: Bearer ${GITHUB_TOKEN}")
+
+  Debug "DEBUG --- API REMAINING DATA BLOCK:"
+  DebugJQ "${API_REMAINING_REQUEST}"
+
+  API_REMAINING_MESSAGE=$(echo ${API_REMAINING_REQUEST} \
+    | jq -r '.message' 2>&1)
+
+  if [[ "${API_REMAINING_MESSAGE}" != "Rate limiting is not enabled." ]]; then
+    API_REMAINING=$(echo ${API_REMAINING_REQUEST} \
+      | jq -r '.resources.graphql.remaining' 2>&1);
+  else
+    API_REMAINING=9999999999
+  fi
 
   #######################
   # Load the error code #
@@ -650,14 +662,14 @@ CheckAPILimit() {
   ##############################
   if [ "${ERROR_CODE}" -ne 0 ]; then
     echo  "ERROR! Failed to get valid response back from GitHub API!"
-    echo "ERROR:[${API_REMAINING_CMD}]"
+    echo "ERROR:[${API_REMAINING}]"
     exit 1
   fi
 
   ##########################################
   # Check to see if we have API calls left #
   ##########################################
-  if [ "${API_REMAINING_CMD}" -eq 0 ]; then
+  if [[ "${API_REMAINING}" -eq 0 ]]; then
     # Increment the sleep counter
     ((SLEEP_COUNTER++))
     # Warn the user
@@ -674,8 +686,10 @@ CheckAPILimit() {
       # Get some sleep...
       sleep "${SLEEP}"
     fi
+  elif [[ "${API_REMAINING}" == 9999999999 ]]; then
+    echo "API rate limiting is not enabled."
   else
-    echo "[${API_REMAINING_CMD}] API attempts remaining..."
+    echo "[${API_REMAINING}] API attempts remaining..."
   fi
 }
 ################################################################################

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -269,7 +269,7 @@ Header() {
   #####################
   # Check GHE version #
   #####################
-  if [[ ! $(isCloud) ]]; then
+  if [[ "$(isCloud)" -eq 0  ]]; then
 
     META_RESPONSE=$(curl -kw '%{http_code}' -s --request GET \
     --url "${GITHUB_URL}"/meta \
@@ -577,9 +577,9 @@ isCloud() {
 ################################################################################
 #### Function isIncompatibleGHESVersion ########################################
 isCompatibleGHESVersion() {
-  if [[ ! $(isCloud) ]] && [[ "${VERSION_MAJOR}" -lt "3" ]]; then
-    if  [[ "${VERSION_MAJOR}" -eq "2" ]] && [[ "${VERSION_MINOR}" -ge "20" ]]; then
-      if [[ "${VERSION_MINOR}" -gt "21" ]]; then
+  if [[ "$(isCloud)" -eq 0  ]] && [[ "${VERSION_MAJOR}" -lt 3 ]]; then
+    if  [[ "${VERSION_MAJOR}" -eq 2 ]] && [[ "${VERSION_MINOR}" -ge 20 ]]; then
+      if [[ "${VERSION_MINOR}" -gt 21 ]]; then
         # GHES >= v2.22 (supported)
         echo 1;
       else

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -642,11 +642,11 @@ CheckAPILimit() {
   Debug "DEBUG --- API REMAINING DATA BLOCK:"
   DebugJQ "${API_REMAINING_REQUEST}"
 
-  API_REMAINING_MESSAGE=$(echo ${API_REMAINING_REQUEST} \
+  API_REMAINING_MESSAGE=$(echo "${API_REMAINING_REQUEST}" \
     | jq -r '.message' 2>&1)
 
   if [[ "${API_REMAINING_MESSAGE}" != "Rate limiting is not enabled." ]]; then
-    API_REMAINING=$(echo ${API_REMAINING_REQUEST} \
+    API_REMAINING=$(echo "${API_REMAINING_REQUEST}" \
       | jq -r '.resources.graphql.remaining' 2>&1);
   else
     API_REMAINING=9999999999

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -291,6 +291,11 @@ Header() {
       echo "${META_DATA}"
     else
       VERSION=$(echo "${META_DATA}" | jq -r '.installed_version')
+
+
+      # Get major/minor versions
+      VERSION_MAJOR=$(echo "${VERSION}" | cut -d "." -f 1);
+      VERSION_MINOR=$(echo "${VERSION}" | cut -d "." -f 2);
     fi
   else
     VERSION="cloud"
@@ -549,6 +554,19 @@ CheckAdminRights() {
   fi
 }
 ################################################################################
+#### Function CheckVersionCompatibility ########################################
+CheckVersionCompatibility() {
+  if [[ "${VERSION_MAJOR}" -lt "3" ]]; then
+    if  [[ "${VERSION_MAJOR}" -eq "2" ]] && [[ "${VERSION_MINOR}" -gt "21" ]]; then
+      echo 0;
+    else
+      echo 1;
+    fi
+  else
+    echo 0;
+  fi
+}
+################################################################################
 #### Function GetOrgsFromFile ##################################################
 GetOrgsFromFile() {
   # shellcheck disable=SC2034
@@ -636,9 +654,13 @@ GetRepos() {
   ##############################
   function generate_graphql_data()
   {
+    IS_EMPTY_FLAG="isEmpty";
+    if [[ "${VERSION_MAJOR}" -lt "3" ]] && [[ "${VERSION_MAJOR}" -lt "22" ]]; then
+      IS_EMPTY_FLAG="";
+    fi
     cat <<EOF
   {
-  "query":"query { organization(login: \"${ORG_NAME}\") { repositories(first:${REPO_PAGE_SIZE}${REPO_NEXT_PAGE}) { totalDiskUsage pageInfo { hasPreviousPage hasNextPage hasPreviousPage endCursor } nodes { owner { login } name nameWithOwner diskUsage isEmpty pushedAt updatedAt isFork collaborators(first:1) { totalCount } branchProtectionRules(first:1) { totalCount } pullRequests(first:${REPO_PAGE_SIZE}) { totalCount pageInfo { hasNextPage endCursor } nodes { number commits(first:1){ totalCount } timeline(first:1) { totalCount } comments(first:1) { totalCount } reviews(first:${REPO_PAGE_SIZE}) { totalCount pageInfo { hasNextPage endCursor } nodes { comments(first:1) { totalCount } } } } } milestones(first:1) { totalCount } commitComments(first:1) { totalCount } issues(first:${REPO_PAGE_SIZE}) { totalCount pageInfo { hasNextPage endCursor } nodes { timeline(first:1) { totalCount } comments(first:1) { totalCount } } } releases(first:1) { totalCount } projects(first:1) { totalCount } } } } }"
+  "query":"query { organization(login: \"${ORG_NAME}\") { repositories(first:${REPO_PAGE_SIZE}${REPO_NEXT_PAGE}) { totalDiskUsage pageInfo { hasPreviousPage hasNextPage hasPreviousPage endCursor } nodes { owner { login } name nameWithOwner diskUsage ${IS_EMPTY_FLAG} pushedAt updatedAt isFork collaborators(first:1) { totalCount } branchProtectionRules(first:1) { totalCount } pullRequests(first:${REPO_PAGE_SIZE}) { totalCount pageInfo { hasNextPage endCursor } nodes { number commits(first:1){ totalCount } timeline(first:1) { totalCount } comments(first:1) { totalCount } reviews(first:${REPO_PAGE_SIZE}) { totalCount pageInfo { hasNextPage endCursor } nodes { comments(first:1) { totalCount } } } } } milestones(first:1) { totalCount } commitComments(first:1) { totalCount } issues(first:${REPO_PAGE_SIZE}) { totalCount pageInfo { hasNextPage endCursor } nodes { timeline(first:1) { totalCount } comments(first:1) { totalCount } } } releases(first:1) { totalCount } projects(first:1) { totalCount } } } } }"
   }
 EOF
   }

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -97,7 +97,7 @@ while (( "$#" )); do
       GHE_URL=$2
       shift 2
       ;;
-    -d|--DEBUG)
+    -d|--debug)
       DEBUG=true
       shift
       ;;

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -269,7 +269,7 @@ Header() {
   #####################
   # Check GHE version #
   #####################
-  if [[ ! isCloud ]]; then
+  if [[ ! $(isCloud) ]]; then
 
     META_RESPONSE=$(curl -kw '%{http_code}' -s --request GET \
     --url "${GITHUB_URL}"/meta \
@@ -577,9 +577,15 @@ isCloud() {
 ################################################################################
 #### Function isIncompatibleGHESVersion ########################################
 isCompatibleGHESVersion() {
-  if [[ ! isCloud ]] && [[ "${VERSION_MAJOR}" -lt "3" ]]; then
-    if  [[ "${VERSION_MAJOR}" -eq "2" ]] && [[ "${VERSION_MINOR}" -gt "21" ]]; then
-      echo 2;
+  if [[ ! $(isCloud) ]] && [[ "${VERSION_MAJOR}" -lt "3" ]]; then
+    if  [[ "${VERSION_MAJOR}" -eq "2" ]]; then
+      if [[ "${VERSION_MINOR}" -gt "21" ]]; then
+        echo 1;
+      elif [[ "${VERSION_MINOR}" -ge "20" ]]; then
+        echo 2;
+      else
+        echo 0;
+      fi
     else
       echo 0;
     fi

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -166,6 +166,9 @@ SLEEP_RETRY_COUNT='15'        # Number of times to try to sleep before giving up
 SLEEP_COUNTER='0'             # Counter of how many times we have gone to sleep
 EXISTING_FILE='0'             # Check if a file already exists
 OUTPUT="${OUTPUT_PARAM:-CSV}" # Output type CSV or Table
+VERSION="cloud"
+VERSION_MAJOR="0"
+VERSION_MINOR="0"
 
 ################################################################################
 ############################ FUNCTIONS #########################################
@@ -298,12 +301,12 @@ Header() {
 
       # Validate supported versions
       if [[ "$(isCompatibleGHESVersion)" -eq "0" ]]; then
-        echo "GitHub Enterprise version ${VERSION} is not supported."
+        echo "GitHub Enterprise Server v${VERSION} is not supported."
         exit 1;
+      else
+        echo "GitHub Enterprise Server v${VERSION}"
       fi
     fi
-  else
-    VERSION="cloud"
   fi
   Debug "Version: ${VERSION}"
 

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -578,18 +578,20 @@ isCloud() {
 #### Function isIncompatibleGHESVersion ########################################
 isCompatibleGHESVersion() {
   if [[ ! $(isCloud) ]] && [[ "${VERSION_MAJOR}" -lt "3" ]]; then
-    if  [[ "${VERSION_MAJOR}" -eq "2" ]]; then
+    if  [[ "${VERSION_MAJOR}" -eq "2" ]] && [[ "${VERSION_MINOR}" -ge "20" ]]; then
       if [[ "${VERSION_MINOR}" -gt "21" ]]; then
+        # GHES >= v2.22 (supported)
         echo 1;
-      elif [[ "${VERSION_MINOR}" -ge "20" ]]; then
-        echo 2;
       else
-        echo 0;
+        # GHES v2.20 & v2.21 (no isEmpty supported)
+        echo 2;
       fi
     else
+      # GHES < v2.20 (not supported)
       echo 0;
     fi
   else
+    # GHEC or GHES >= v3 (supported)
     echo 1;
   fi
 }


### PR DESCRIPTION
Attempting to detect version and exit when version is less than 2.20 (GraphQL endpoints were introduced then).

Also adding support for 2.20 and 2.21 as the `isEmpty` property did not exist yet.