### PR TITLE
GitHub App token support, updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Get Repository Statistics
 
 **GitHub CLI** extensions are repositories that provide additional `gh` commands, and this **GitHub CLI** extension can help you find information about your repositories in your organizations.
+
 This information outlines the underlying **GitHub** `metadata` associated with your repository. This information is key to understanding how long a migration of the data from one instance of **GitHub** to another will take.
+
 When the extension is run to completion, you will be presented with a visual table, or `*.csv` file to parse for all relevant information.
 
 ## GHES Compatibility
@@ -17,13 +19,23 @@ The **gh-repo-stats** extension supports the following versions of GitHub Enterp
 - Operating system that can run shell scripts (*bash/sh*)
 - **GitHub CLI** installed by following this documentation: <https://github.com/cli/cli#installation>
 - **jq** command-line JSON parser: <https://stedolan.github.io/jq/>
+- GitHub Personal Access Token (PAT) with appropriate permissions by `--token-type`:
+  - `user` with `admin:org`, `user:all`, and `repo:all` permissions
+  - `app` with [GitHub App server-to-server token](https://docs.github.com/en/developers/overview/managing-deploy-keys#server-to-server-tokens) with `Read-only` permissions to the following:
+    - Repository Administration
+    - Repository Contents
+    - Repository Issues
+    - Repository Metadata
+    - Repository Projects
+    - Repository Pull requests
+    - Organization Members
 
 You need to either export these environment variables:
 
-| Environment Variable name | Value                                                                                       |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| GITHUB_TOKEN              | GitHub Personal Access Token (PAT) with `admin:org`, `user:all`, and `repo:all` permissions |
-| GHE_URL                   | GitHub URL or GHES URL without HTTP or HTTPS. Defaults to `https://github.com`.             |
+| Environment Variable name | Value                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| GITHUB_TOKEN              | GitHub Personal Access Token (PAT) as described above                           |
+| GHE_URL                   | GitHub URL or GHES URL without HTTP or HTTPS. Defaults to `https://github.com`. |
 
 Or the script will prompt you to put in the relevant information.
 
@@ -40,6 +52,7 @@ Options:
     -i, --input                   : Set path to a file with a list of organizations to scan, one per line, newline delimited
     -t, --token                   : Set Personal Access Token with repo scope - Looks for GITHUB_TOKEN environment
                                     variable if omitted
+    -y, --token-type              : Type of Personal Access. Can either "user" or "app" Default: user
     -r, --analyze-repo-conflicts  : Checks the Repo Name against repos in other organizations and generates a list
                                     of potential naming conflicts if those orgs are to be merged during migration
     -T, --analyze-team-conflicts  : Gathers each org's teams and checks against other orgs to generate a list of
@@ -67,7 +80,7 @@ gh extension install mona-actions/gh-repo-stats
 ### Step 2: Run gh repo-stats
 
 ```sh
-gh repo-stats --org <ORG_NAME> --ghe-url <GHE_URL> --token <GITHUB_TOKEN>
+gh repo-stats --org <ORG_NAME> --url <GHE_URL> --token <GITHUB_TOKEN>
 ```
 
 ### Example Output
@@ -75,9 +88,9 @@ gh repo-stats --org <ORG_NAME> --ghe-url <GHE_URL> --token <GITHUB_TOKEN>
 ![Output 1](./screenshots/output1.png)
 ![Output 2](./screenshots/output2.png)
 
-### CSV
+### Step 3: Review CSV report for migration issue(s)
 
-Once the script has completed you will have either an inline table, or a genereted `csv` you can use to parse data.
+Once the script has completed you will have either an inline table, or a genereted `csv` you can use to parse data:
 
 ```csv
 Org_Name,Repo_Name,Is_Empty,Last_Push,Last_Update,isFork,Repo_Size(mb),Record_Count,Collaborator_Count,Protected_Branch_Count,PR_Review_Count,Milestone_Count,Issue_Count,PR_Count,PR_Review_Comment_Count,Commit_Comment_Count,Issue_Comment_Count,Issue_Event_Count,Release_Count,Project_Count,Full_URL,Migration_Issue
@@ -87,3 +100,7 @@ lukaspersonal,hubot,false,2018-03-05T19:00:08Z,2018-01-26T17:55:49Z,false,0,6,1,
 lukaspersonal,webhooklistener,false,2018-01-26T18:20:03Z,2018-01-26T18:20:04Z,false,0,5,1,0,0,0,4,0,0,0,0,0,0,0,https://github.com/lukaspersonal/webhooklistener,FALSE
 lukaspersonal,jenkins,false,2018-03-14T13:20:59Z,2018-03-14T13:21:00Z,false,0,11,1,0,0,0,4,2,0,0,0,4,0,0,https://github.com/lukaspersonal/jenkins,FALSE
 ```
+
+The `Migration_Issue` column indicates whether the repository might have a problem during migration due to one or more conditions:
+- 60,000 or more number of objects being imported
+- 1.5 GB or larger size on disk

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -64,6 +64,7 @@ Options:
     -i, --input                   : Set path to a file with a list of organizations to scan, one per line, newline delimited
     -t, --token                   : Set Personal Access Token with repo scope - Looks for GITHUB_TOKEN environment
                                     variable if omitted
+    -y, --token-type              : Type of Personal Access. Can either "user" or "app" Default: user
     -r, --analyze-repo-conflicts  : Checks the Repo Name against repos in other organizations and generates a list
                                     of potential naming conflicts if those orgs are to be merged during migration
     -T, --analyze-team-conflicts  : Gathers each org's teams and checks against other orgs to generate a list of
@@ -104,6 +105,10 @@ while (( "$#" )); do
       ;;
     -t|--token)
       GITHUB_TOKEN=$2
+      shift 2
+      ;;
+    -y|--token-type)
+      GITHUB_TOKEN_TYPE=$2
       shift 2
       ;;
     -i|--input)
@@ -166,12 +171,13 @@ GITHUB_TOKEN=${GITHUB_TOKEN:-}         # Default to environment variable
 ###########
 # GLOBALS #
 ###########
-SLEEP='300'                   # Number of seconds to sleep if out of API calls
-SLEEP_RETRY_COUNT='15'        # Number of times to try to sleep before giving up
-SLEEP_COUNTER='0'             # Counter of how many times we have gone to sleep
-EXISTING_FILE='0'             # Check if a file already exists
-OUTPUT="${OUTPUT_PARAM:-CSV}" # Output type CSV or Table
-REPO_LIST_ARRAY=()            # Array of repo names to be analyzed
+SLEEP='300'                                   # Number of seconds to sleep if out of API calls
+SLEEP_RETRY_COUNT='15'                        # Number of times to try to sleep before giving up
+SLEEP_COUNTER='0'                             # Counter of how many times we have gone to sleep
+EXISTING_FILE='0'                             # Check if a file already exists
+OUTPUT="${OUTPUT_PARAM:-CSV}"                 # Output type CSV or Table
+REPO_LIST_ARRAY=()                            # Array of repo names to be analyzed
+GITHUB_TOKEN_TYPE=${GITHUB_TOKEN_TYPE:-user}  # Whether 'user' or 'app' PAT
 VERSION="cloud"
 VERSION_MAJOR="0"
 VERSION_MINOR="0"
@@ -240,38 +246,40 @@ Header() {
   ################################################################
   # Validate we can hit the endpoint by getting the current user #
   ################################################################
-  Debug "curl -kw '%{http_code}' -s -X GET \
-  --url ${GITHUB_URL}/user \
-  -H \"authorization: Bearer ************\""
-
-  USER_RESPONSE=$(curl -kw '%{http_code}' -s -X GET \
-    --url "${GITHUB_URL}"/user \
-    -H "authorization: Bearer ${GITHUB_TOKEN}")
-
-  Debug "USER_RESPONSE: "
-  Debug "${USER_RESPONSE}"
-
-  USER_RESPONSE_CODE="${USER_RESPONSE:(-3)}"
-  USER_DATA="${USER_RESPONSE::${#USER_RESPONSE}-4}"
-
-  DebugJQ "${USER_DATA}"
-
-  #######################
-  # Validate the return #
-  #######################
-  if [[ "$USER_RESPONSE_CODE" != "200" ]]; then
-    echo "Error getting user"
-    echo "${USER_DATA}"
-  else
-    USER_LOGIN=$(echo "${USER_DATA}" | jq -r '.login')
-    # Check for success
-    if [[ -z ${USER_LOGIN} ]]; then
-      # Got bad return
-      echo "ERROR! Failed to validate GHE instance:[${GITHUB_URL}]"
-      echo "Received error: ${USER_DATA}"
-      exit 1
+  if [[ ${GITHUB_TOKEN_TYPE} == "user" ]]; then
+    Debug "curl -kw '%{http_code}' -s -X GET \
+    --url ${GITHUB_URL}/user \
+    -H \"authorization: Bearer ************\""
+  
+    USER_RESPONSE=$(curl -kw '%{http_code}' -s -X GET \
+      --url "${GITHUB_URL}"/user \
+      -H "authorization: Bearer ${GITHUB_TOKEN}")
+  
+    Debug "USER_RESPONSE: "
+    Debug "${USER_RESPONSE}"
+  
+    USER_RESPONSE_CODE="${USER_RESPONSE:(-3)}"
+    USER_DATA="${USER_RESPONSE::${#USER_RESPONSE}-4}"
+  
+    DebugJQ "${USER_DATA}"
+  
+    #######################
+    # Validate the return #
+    #######################
+    if [[ "$USER_RESPONSE_CODE" != "200" ]]; then
+      echo "Error getting user"
+      echo "${USER_DATA}"
     else
-      Debug "Successfully validated access to GHE Instance..."
+      USER_LOGIN=$(echo "${USER_DATA}" | jq -r '.login')
+      # Check for success
+      if [[ -z ${USER_LOGIN} ]]; then
+        # Got bad return
+        echo "ERROR! Failed to validate GHE instance:[${GITHUB_URL}]"
+        echo "Received error: ${USER_DATA}"
+        exit 1
+      else
+        Debug "Successfully validated access to GHE Instance..."
+      fi
     fi
   fi
 
@@ -535,6 +543,12 @@ GenerateFiles() {
 ################################################################################
 #### Function CheckAdminRights #################################################
 CheckAdminRights() {
+
+  if [[ ${GITHUB_TOKEN_TYPE} == "app" ]]; then
+    echo "Skip checking user PAT admin rights for GitHub App token"
+    return 0
+  fi
+
   ################
   # Pull in vars #
   ################


### PR DESCRIPTION
fixes #33
fixes #34

This commit is a bit of a crude workaround for usage where the token is a server-to-server GitHub App token for higher rate limits and fixing some documentation typos and missing information.

Unlike APIs for authenticated user PATs, the GitHub App installation tokens doesn't have the same capabilities, so this PR bypasses some of the checks previously used for testing if the PAT has the necessary permissions and simply does the job.

Along with that, this PR fixes documentation as `--ghe-url` was an invalid flag and our docs didn't explain what to do with the results.