### PR TITLE
Compatibility with Windows Git Bash

### DIFF
--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -471,7 +471,7 @@ CheckAdminRights() {
   ##################
   # Get membership #
   ##################
-  MEMBERSHIP_DATA=$(gh api orgs/${ORG_NAME}/memberships/${USER_LOGIN})
+  MEMBERSHIP_DATA=$(gh api "orgs/${ORG_NAME}/memberships/${USER_LOGIN}")
   ERROR_CODE=$?
 
   if [ "${ERROR_CODE}" -ne 0 ]; then

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -213,7 +213,7 @@ Header() {
   echo ""
   echo "######################################################"
   echo "######################################################"
-  echo "############# Amenocal GitHub repo list and sizer #############"
+  echo "############# GitHub repo list and sizer #############"
   echo "######################################################"
   echo "######################################################"
   echo ""
@@ -493,7 +493,13 @@ CheckAdminRights() {
 ################################################################################
 #### Function isGHEC ###########################################################
 isCloud() {
-  ROOT_DATA=$(gh api //)
+  if [[ "$OSTYPE" == "msys" ]]; then
+    # If the operating system is Windows escape leading slash
+    ROOT_DATA=$(gh api //)
+  else
+    # If the operating system is Unix-like (e.g., Linux, macOS)
+    ROOT_DATA=$(gh api /)
+  fi
   USER_URL=$(echo -n "${ROOT_DATA}" | jq -r '.current_user_url')
 
   if [[ "${USER_URL}" != "https://api.github.com/user" ]]; then
@@ -797,9 +803,7 @@ ParseRepos() {
   PARSE_DATA=$1
 
   REPOS=$(echo "${PARSE_DATA}" | jq -r '.data.organization.repositories.nodes')
-  echo "decoding repos"
-  echo "${REPOS}"
-  for REPO_DATA in $(echo -n "${REPOS}" | jq -r '.[] | @base64' | tr -d '\n'); do
+  for REPO_DATA in $(echo -n "${REPOS}" | jq -r '.[] | @base64'); do
     _jq() {
     echo -n "${REPO_DATA}" | base64 --decode | jq -r "${1}"
     }
@@ -850,8 +854,6 @@ ParseRepoData() {
   # Pull in the repos data block
   REPO_DATA=$1
   # Convert the format to JSON
-  echo "decoding repo data"
-  echo "${REPO_DATA}"
   _jq() {
     echo -n "${REPO_DATA}" | base64 --decode | jq -r "${1}"
   }
@@ -974,8 +976,7 @@ ParseRepoData() {
 #### Function AnalyzeIssues ####################################################
 AnalyzeIssues() {
   THIS_REPO=$1
-  echo "decoding AnalyzeIssues THIS_REPO"
-  echo "${THIS_REPO}"
+
   _pr_issue_jq() {
    echo -n "${THIS_REPO}" | base64 --decode | jq -r "${1}"
   }
@@ -991,9 +992,8 @@ AnalyzeIssues() {
   # Get the Current End Cursor #
   ##############################
   ISSUE_NEXT_PAGE=$(_pr_issue_jq  '.issues.pageInfo.endCursor')
-  echo "decoding ISSUES"
-  echo "${ISSUES}"
-  for ISSUE in $(echo -n "${ISSUES}" | jq -r '.[] | @base64' | tr -d '\n'); do
+
+  for ISSUE in $(echo -n "${ISSUES}" | jq -r '.[] | @base64'); do
     _issue_jq() {
       echo -n "${ISSUE}" | base64 --decode | jq -r "${1}"
     }
@@ -1077,8 +1077,7 @@ GetNextIssues() {
       echo "ERROR --- Errors occurred while retrieving issues for repo: ${REPO_NAME}"
       echo "${ERROR_MESSAGE}" | jq '.'
     fi
-    echo "deocding ISSUE_REPO"
-    echo "${ISSUE_REPO}"
+    
     ISSUE_REPO=$(echo -n "${ISSUE_DATA}" | jq -r '.data.repository | @base64')
 
     ######################
@@ -1091,8 +1090,6 @@ GetNextIssues() {
 #### Function AnalyzePullRequests ##############################################
 AnalyzePullRequests() {
   PR_REPO=$1
-  echo "decoding AnalyzePullRequests PR_REPO"
-  echo "${PR_REPO}"
   _pr_repo_jq() {
    echo -n "${PR_REPO}" | base64 --decode | jq -r "${1}"
   }
@@ -1110,11 +1107,9 @@ AnalyzePullRequests() {
   # Get the Current End Cursor #
   ##############################
   PR_NEXT_PAGE=$(_pr_repo_jq  '.pullRequests.pageInfo.endCursor')
-  echo "decoding PRS"
-  echo "${PRS}"
-  for PR in $(echo -n "${PRS}" | jq -r '.[] | @base64' | tr -d '\n'); do
+  for PR in $(echo -n "${PRS}" | jq -r '.[] | @base64'); do
     _pr_jq() {
- echo -n "${PR}" | base64 --decode | jq -r "${1}"
+    echo -n "${PR}" | base64 --decode | jq -r "${1}"
     }
 
     PR_NUMBER=$(_pr_jq '.number')
@@ -1241,8 +1236,7 @@ GetNextPullRequests() {
       echo "ERROR --- Errors occurred while retrieving pull requests for repo: ${REPO_NAME}"
       echo "${ERROR_MESSAGE}" | jq '.'
     fi
-    echo "decoding PR_REPO"
-    echo "${PR_REPO}"
+
     PR_REPO=$(echo -n "${PR_DATA}" | jq -r '.data.repository | @base64')
 
     AnalyzePullRequests "${PR_REPO}"
@@ -1252,8 +1246,7 @@ GetNextPullRequests() {
 #### Function AnalyzeReviews ###################################################
 AnalyzeReviews() {
   REVIEW_PR=$1
-  echo "decoding AnalyzeReviews REVIEW_PR"
-  echo "${REVIEW_PR}"
+
   _review_jq() {
    echo -n "${REVIEW_PR}" | base64 --decode | jq -r "${1}"
   }
@@ -1272,8 +1265,7 @@ AnalyzeReviews() {
   PR_NUMBER=$(_review_jq '.number')
 
   Debug "Analyzing Pull Request Reviews for: ${REPO_NAME} PR: ${PR_NUMBER}"
-  echo "decoding REVIEWS"
-  echo "${REVIEWS}"
+
   for REVIEW in $(echo -n "${REVIEWS}" | jq -r '.[] | @base64'); do
     _pr_jq() {
  echo -n "${REVIEW}" | base64 --decode | jq -r "${1}"
@@ -1380,8 +1372,6 @@ GetNextReviews() {
     #####################
     # Get the Review PR #
     #####################
-    echo "decoding REVIEW_PR"
-    echo "${REVIEW_PR}"
     REVIEW_PR=$(echo -n "${REVIEW_DATA}" | jq -r '.data.repository.pullRequest | @base64')
 
     ######################
@@ -1439,8 +1429,7 @@ GetTeams() {
     # Get the Current End Cursor #
     ##############################
     TEAM_NEXT_PAGE=$(echo "${TEAM_DATA}" | jq -r '.data.organization.teams.pageInfo.endCursor')
-    echo "decoding teams"
-    echo "${TEAMS}"
+    
     for TEAM in $(echo -n "${TEAMS}" | jq -r '.[] | @base64'); do
       _team_jq() {
         echo -n "${TEAM}" | base64 --decode | jq -r "${1}"

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -213,7 +213,7 @@ Header() {
   echo ""
   echo "######################################################"
   echo "######################################################"
-  echo "############# GitHub repo list and sizer #############"
+  echo "############# Amenocal GitHub repo list and sizer #############"
   echo "######################################################"
   echo "######################################################"
   echo ""
@@ -222,7 +222,7 @@ Header() {
   # Validate we can hit the endpoint by getting the current user #
   ################################################################
   if [[ ${GITHUB_TOKEN_TYPE} == "user" ]]; then
-    USER_DATA=$(gh api /user)
+    USER_DATA=$(gh api user)
     ERROR_CODE=$?
   
     #######################
@@ -249,7 +249,7 @@ Header() {
   # Check GHE version #
   #####################
   if [[ "$(isCloud)" -eq 0  ]]; then
-    META_DATA=$(gh api /meta)
+    META_DATA=$(gh api meta)
     ERROR_CODE=$?
 
     #######################
@@ -471,7 +471,7 @@ CheckAdminRights() {
   ##################
   # Get membership #
   ##################
-  MEMBERSHIP_DATA=$(gh api "/orgs/${ORG_NAME}/memberships/${USER_LOGIN}")
+  MEMBERSHIP_DATA=$(gh api orgs/${ORG_NAME}/memberships/${USER_LOGIN})
   ERROR_CODE=$?
 
   if [ "${ERROR_CODE}" -ne 0 ]; then
@@ -493,7 +493,7 @@ CheckAdminRights() {
 ################################################################################
 #### Function isGHEC ###########################################################
 isCloud() {
-  ROOT_DATA=$(gh api /)
+  ROOT_DATA=$(gh api //)
   USER_URL=$(echo -n "${ROOT_DATA}" | jq -r '.current_user_url')
 
   if [[ "${USER_URL}" != "https://api.github.com/user" ]]; then
@@ -560,7 +560,7 @@ CheckAPILimit() {
   ##############################################################
   # Check what is remaining, and if 0, we need to sleep it off #
   ##############################################################
-  API_REMAINING_REQUEST=$(gh api /rate_limit)
+  API_REMAINING_REQUEST=$(gh api rate_limit)
   API_REMAINING_MESSAGE=$(echo "${API_REMAINING_REQUEST}" | jq -r '.message' 2>&1)
 
   if [[ "${API_REMAINING_MESSAGE}" != "Rate limiting is not enabled." ]]; then
@@ -797,7 +797,9 @@ ParseRepos() {
   PARSE_DATA=$1
 
   REPOS=$(echo "${PARSE_DATA}" | jq -r '.data.organization.repositories.nodes')
-  for REPO_DATA in $(echo -n "${REPOS}" | jq -r '.[] | @base64'); do
+  echo "decoding repos"
+  echo "${REPOS}"
+  for REPO_DATA in $(echo -n "${REPOS}" | jq -r '.[] | @base64' | tr -d '\n'); do
     _jq() {
     echo -n "${REPO_DATA}" | base64 --decode | jq -r "${1}"
     }
@@ -848,6 +850,8 @@ ParseRepoData() {
   # Pull in the repos data block
   REPO_DATA=$1
   # Convert the format to JSON
+  echo "decoding repo data"
+  echo "${REPO_DATA}"
   _jq() {
     echo -n "${REPO_DATA}" | base64 --decode | jq -r "${1}"
   }
@@ -970,7 +974,8 @@ ParseRepoData() {
 #### Function AnalyzeIssues ####################################################
 AnalyzeIssues() {
   THIS_REPO=$1
-
+  echo "decoding AnalyzeIssues THIS_REPO"
+  echo "${THIS_REPO}"
   _pr_issue_jq() {
    echo -n "${THIS_REPO}" | base64 --decode | jq -r "${1}"
   }
@@ -986,8 +991,9 @@ AnalyzeIssues() {
   # Get the Current End Cursor #
   ##############################
   ISSUE_NEXT_PAGE=$(_pr_issue_jq  '.issues.pageInfo.endCursor')
-
-  for ISSUE in $(echo -n "${ISSUES}" | jq -r '.[] | @base64'); do
+  echo "decoding ISSUES"
+  echo "${ISSUES}"
+  for ISSUE in $(echo -n "${ISSUES}" | jq -r '.[] | @base64' | tr -d '\n'); do
     _issue_jq() {
       echo -n "${ISSUE}" | base64 --decode | jq -r "${1}"
     }
@@ -1071,7 +1077,8 @@ GetNextIssues() {
       echo "ERROR --- Errors occurred while retrieving issues for repo: ${REPO_NAME}"
       echo "${ERROR_MESSAGE}" | jq '.'
     fi
-
+    echo "deocding ISSUE_REPO"
+    echo "${ISSUE_REPO}"
     ISSUE_REPO=$(echo -n "${ISSUE_DATA}" | jq -r '.data.repository | @base64')
 
     ######################
@@ -1084,7 +1091,8 @@ GetNextIssues() {
 #### Function AnalyzePullRequests ##############################################
 AnalyzePullRequests() {
   PR_REPO=$1
-
+  echo "decoding AnalyzePullRequests PR_REPO"
+  echo "${PR_REPO}"
   _pr_repo_jq() {
    echo -n "${PR_REPO}" | base64 --decode | jq -r "${1}"
   }
@@ -1102,8 +1110,9 @@ AnalyzePullRequests() {
   # Get the Current End Cursor #
   ##############################
   PR_NEXT_PAGE=$(_pr_repo_jq  '.pullRequests.pageInfo.endCursor')
-
-  for PR in $(echo -n "${PRS}" | jq -r '.[] | @base64'); do
+  echo "decoding PRS"
+  echo "${PRS}"
+  for PR in $(echo -n "${PRS}" | jq -r '.[] | @base64' | tr -d '\n'); do
     _pr_jq() {
  echo -n "${PR}" | base64 --decode | jq -r "${1}"
     }
@@ -1232,7 +1241,8 @@ GetNextPullRequests() {
       echo "ERROR --- Errors occurred while retrieving pull requests for repo: ${REPO_NAME}"
       echo "${ERROR_MESSAGE}" | jq '.'
     fi
-
+    echo "decoding PR_REPO"
+    echo "${PR_REPO}"
     PR_REPO=$(echo -n "${PR_DATA}" | jq -r '.data.repository | @base64')
 
     AnalyzePullRequests "${PR_REPO}"
@@ -1242,7 +1252,8 @@ GetNextPullRequests() {
 #### Function AnalyzeReviews ###################################################
 AnalyzeReviews() {
   REVIEW_PR=$1
-
+  echo "decoding AnalyzeReviews REVIEW_PR"
+  echo "${REVIEW_PR}"
   _review_jq() {
    echo -n "${REVIEW_PR}" | base64 --decode | jq -r "${1}"
   }
@@ -1261,7 +1272,8 @@ AnalyzeReviews() {
   PR_NUMBER=$(_review_jq '.number')
 
   Debug "Analyzing Pull Request Reviews for: ${REPO_NAME} PR: ${PR_NUMBER}"
-
+  echo "decoding REVIEWS"
+  echo "${REVIEWS}"
   for REVIEW in $(echo -n "${REVIEWS}" | jq -r '.[] | @base64'); do
     _pr_jq() {
  echo -n "${REVIEW}" | base64 --decode | jq -r "${1}"
@@ -1368,6 +1380,8 @@ GetNextReviews() {
     #####################
     # Get the Review PR #
     #####################
+    echo "decoding REVIEW_PR"
+    echo "${REVIEW_PR}"
     REVIEW_PR=$(echo -n "${REVIEW_DATA}" | jq -r '.data.repository.pullRequest | @base64')
 
     ######################
@@ -1425,7 +1439,8 @@ GetTeams() {
     # Get the Current End Cursor #
     ##############################
     TEAM_NEXT_PAGE=$(echo "${TEAM_DATA}" | jq -r '.data.organization.teams.pageInfo.endCursor')
-
+    echo "decoding teams"
+    echo "${TEAMS}"
     for TEAM in $(echo -n "${TEAMS}" | jq -r '.[] | @base64'); do
       _team_jq() {
         echo -n "${TEAM}" | base64 --decode | jq -r "${1}"


### PR DESCRIPTION
This pull request primarily refactors the `gh-repo-stats` file to improve the GitHub API calls and adds a new condition to handle Windows operating systems. The changes include modifying the API endpoint calls,  and adding a condition to handle leading slashes in Windows operating systems.

related issue https://github.com/cli/cli/issues/6415

> [!WARNING]  
> When running this in a `windows-latest` I kept getting `base64: invalid`. However, the `.csv` output file contained accurate info on repos I checked
> <details><summary>Log</summary>
><p>
>
>Analyzing Repo: actions-demo
>base64: invalid input
>base64: invalid input
>base64: invalid input
>base64: invalid input
>base64: invalid input
>
></p>
></details> 