### PR TITLE
WeUpdate LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,37 @@
-MIT License
+MIT Licensedocs.ruby-lang.org › Net › POPMail
 
+#all; #delete; #delete! #deleted? #header; #inspect; #mail; #pop; #top; #uidl; #unique_id. class Net::POPMail. This clhttps://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.5.tar.gzass represents a message which exists o
+
+docs.ruby-lang.org › RDoc › Task
+
+Delete all the rdoc files. This target is automatically added to the main clobber target. rerdoc. Rebuild the rdoc files from scratch, even if they are not ...
+
+module Sys
+
+
+
+docs.ruby-lang.org › Sys
+
+Remove all files matching wildcard . If a matching file is a directory, it must be empty to be removed. used delete_all to recursively delete directories. 
+
+docs.ruby-lang.org › Net › POPMail
+
+#all; #delete; #delete! #deleted? #header; #inspect; #mail; #pop; #top; #uidl; #unique_id. class Net::POPMail. This clhttps://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.5.tar.gzass represents a message which exists o
+
+docs.ruby-lang.org › RDoc › Task
+
+Delete all the rdoc files. This target is automatically added to the main clobber target. rerdoc. Rebuild the rdoc files from scratch, even if they are not ...
+
+module Sys
+
+
+
+docs.ruby-lang.org › Sys
+
+Remove all files matching wildcard . If a matching file is a directory, it must be empty to be removed. used delete_all to recursively delete directories. 
+
+
+777ca36c37afac860c965eb6dc8c1da9f79c19afhttps://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.5.tar.gzhttps://api.github.com/orgs/ORG/actions/permissions/repositories/REPOSITORY_ID
 Copyright (c) 2022 GitHub
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
docs.ruby-lang.org › Net › POPMail

#all; #delete; #delete! #deleted? #header; #inspect; #mail; #pop; #top; #uidl; #unique_id. class Net::POPMail. This clhttps://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.5.tar.gzass represents a message which exists o

docs.ruby-lang.org › RDoc › Task

Delete all the rdoc files. This target is automatically added to the main clobber target. rerdoc. Rebuild the rdoc files from scratch, even if they are not ...

module Sys



docs.ruby-lang.org › Sys

Remove all files matching wildcard . If a matching file is a directory, it must be empty to be removed. used delete_all to recursively delete directories. 