### PR TITLE
fix wrong argument in query

### DIFF
--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -1386,7 +1386,7 @@ GetTeams() {
 
   QUERY="query(\$owner: String!, \$pageSize: Int!, \$endCursor: String) {
     organization(login: \$owner) {
-      teams(first: \$pageSize, endCursor: \$endCursor) {
+      teams(first: \$pageSize, after: \$endCursor) {
         pageInfo {
           hasNextPage
           endCursor


### PR DESCRIPTION
This pull request includes a change to the `GetTeams()` function in the `gh-repo-stats` file. The change modifies the GraphQL query to use the correct pagination parameter.

* [`gh-repo-stats`](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffL1389-R1389): Modified the `GetTeams()` function to use `after` parameter for pagination instead of `endCursor`.