### PR TITLE
Comment out projects field in gh-repo-stats

### DIFF
--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -678,9 +678,9 @@ GetRepos() {
           owner {
             login
           }
-          projects {
-            totalCount
-          }
+#          projects {
+#            totalCount
+#          }
           pullRequests(first: \$pageSize) {
             totalCount
             pageInfo {


### PR DESCRIPTION
Comment out the projects field in the query. This part caused non-zero error code and thus the whole script fails every time.