### PR TITLE
Rename 'projects' to 'projectsV2' in query

### DIFF
--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -678,7 +678,7 @@ GetRepos() {
           owner {
             login
           }
-          projects {
+          projectsV2 {
             totalCount
           }
           pullRequests(first: \$pageSize) {


### PR DESCRIPTION
Update the GraphQL query to reflect the new projectsV2 object. 