### PR TITLE
Add read:project to README permissions for user tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Example:
 
 The permissions needed by `gh repo-stats` depends based on `-y, --token-type`:
 
-- `user`: `admin:org`, `user:all`, and `repo:all`
+- `user`: `admin:org`, `user:all`, `repo:all`, and `read:project`
 - `app` with [GitHub App server-to-server token](https://docs.github.com/en/developers/overview/managing-deploy-keys#server-to-server-tokens) with `Read-only` permissions to the following:
   - Repository Administration
   - Repository Contents


### PR DESCRIPTION
This PR updates the README to include the `read:project` scope for user PATs.

When running:
```bash
gh repo-stats --org <ORG_NAME> -t <TOKEN>
```

I encountered the following error:
> The 'projectsV2' field requires one of the following scopes: ['read:project']

My user PAT already had:
- admin:org
- user:all
- repo:all

Adding the read:project scope resolved the error.

Since gh-repo-stats now uses the projectsV2 field, user tokens need the read:project scope to work correctly, so this PR updates the Permissions section accordingly.