### PR TITLE
Add JSON output for repo statistics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Options:
      -H, --hostname                : The GitHub hostname for the request
                                      Default: github.com
      -i, --input                   : Set path to a file with a list of organizations to scan, one per line, newline delimited
+     -J, --json                    : Output results in JSON format instead of CSV
+                                     Conforms to the schema defined in json-schema.md
      -o, --org                     : Name of the GitHub Organization to be analyzed
      -O, --output                  : Format of output, can either be "CSV" or "Table"
                                      Default: CSV
@@ -49,6 +51,7 @@ Description:
 Example:
   gh repo-stats -o my-org-name
   gh repo-stats -o my-org-name -H github.example.com
+  gh repo-stats -o my-org-name --json
 ```
 
 ## Permissions
@@ -69,7 +72,7 @@ The permissions needed by `gh repo-stats` depends based on `-y, --token-type`:
 
 ## Output
 
-`gh repo-stats` produces either a visual table or `*.csv` file containing detailed information about various records within repositories.
+`gh repo-stats` produces either a visual table or `*.csv` file containing detailed information about various records within repositories. When the `--json` (`-J`) flag is provided, output is written as JSON conforming to the schema defined in [`json-schema.md`](docs/json-schema.md). The output conforms to the [gh-stats-visualizer](https://github.com/mona-actions/gh-stats-visualizer) input format.
 
 ```csv
 Org_Name,Repo_Name,Is_Empty,Last_Push,Last_Update,isFork,isArchive,Repo_Size(mb),Record_Count,Collaborator_Count,Protected_Branch_Count,PR_Review_Count,Milestone_Count,Issue_Count,PR_Count,PR_Review_Comment_Count,Commit_Comment_Count,Issue_Comment_Count,Issue_Event_Count,Release_Count,Project_Count,Branch_Count,Tag_Count,Discussion_Count,Has_Wiki,Full_URL,Migration_Issue,Created

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -1,0 +1,96 @@
+# gh-repo-stats JSON Schema Specification
+
+This document defines the JSON output format produced by `gh-repo-stats --json`.
+
+---
+
+## Table of Contents
+
+- [Top-Level Structure](#top-level-structure)
+- [Repository Object](#repository-object-repos)
+  - [Core Fields](#core-fields)
+- [Example](#example)
+
+---
+
+## Top-Level Structure
+
+```json
+{
+  "repos": []
+}
+```
+
+| Field  | Type    | Required | Description                                                |
+| ------ | ------- | -------- | ---------------------------------------------------------- |
+| `repos`| `array` | ✅        | Array of [repository objects](#repository-object-repos)    |
+
+---
+
+## Repository Object (`repos[]`)
+
+### Core Fields
+
+| Field               | Type      | Description                                           |
+| ------------------- | --------- | ----------------------------------------------------- |
+| `org`               | `string`  | Organization name                                     |
+| `name`              | `string`  | Repository name                                       |
+| `url`               | `string`  | Repository URL                                        |
+| `isFork`            | `boolean` | Whether the repository is a fork                      |
+| `isArchived`        | `boolean` | Whether the repository is archived                    |
+| `diskUsage`         | `number`  | Repository size in **KB**                             |
+| `sizeMB`            | `number`  | Repository size in **MB**                             |
+| `hasWikiEnabled`    | `boolean` | Whether the wiki is enabled                           |
+| `createdAt`         | `string`  | ISO 8601 creation timestamp                           |
+| `updatedAt`         | `string`  | ISO 8601 last update timestamp                        |
+| `pushedAt`          | `string`  | ISO 8601 last push timestamp                          |
+| `collaborators`     | `number`  | Number of collaborators                               |
+| `branches`          | `number`  | Number of branches                                    |
+| `tags`              | `number`  | Number of tags                                        |
+| `branchProtections` | `number`  | Number of branch protection rules                     |
+| `issues`            | `number`  | Total issue count                                     |
+| `pullRequests`      | `number`  | Total pull request count                              |
+| `milestones`        | `number`  | Number of milestones                                  |
+| `releases`          | `number`  | Number of releases                                    |
+| `projects`          | `number`  | Number of projects                                    |
+| `discussions`       | `number`  | Number of discussions                                 |
+| `commitComments`    | `number`  | Number of commit comments                             |
+| `issueEvents`       | `number`  | Number of issue events                                |
+
+All fields are always present in the output.
+
+---
+
+## Example
+
+```json
+{
+  "repos": [
+    {
+      "org": "my-org",
+      "name": "my-repo",
+      "url": "https://github.com/my-org/my-repo",
+      "isFork": false,
+      "isArchived": false,
+      "diskUsage": 51200,
+      "sizeMB": 50,
+      "hasWikiEnabled": false,
+      "createdAt": "2024-01-15T10:30:00Z",
+      "updatedAt": "2025-06-01T14:00:00Z",
+      "pushedAt": "2025-06-01T14:00:00Z",
+      "collaborators": 12,
+      "branches": 8,
+      "tags": 15,
+      "branchProtections": 2,
+      "issues": 45,
+      "pullRequests": 120,
+      "milestones": 4,
+      "releases": 12,
+      "projects": 2,
+      "discussions": 8,
+      "commitComments": 5,
+      "issueEvents": 350
+    }
+  ]
+}
+```

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -60,6 +60,7 @@ SLEEP_RETRY_COUNT='15'                        # Number of times to try to sleep 
 SLEEP_COUNTER='0'                             # Counter of how many times we have gone to sleep
 EXISTING_FILE='0'                             # Check if a file already exists
 OUTPUT="${OUTPUT_PARAM:-CSV}"                 # Output type CSV or Table
+JSON_OUTPUT=0                             # Enable JSON output (0=disabled, 1=enabled)
 REPO_LIST_ARRAY=()                            # Array of repo names to be analyzed
 GITHUB_TOKEN_TYPE=${GITHUB_TOKEN_TYPE:-user}  # Whether 'user' or 'app' PAT
 VERSION="cloud"
@@ -83,6 +84,8 @@ Options:
      -H, --hostname                : The GitHub hostname for the request
                                      Default: github.com
      -i, --input                   : Set path to a file with a list of organizations to scan, one per line, newline delimited
+     -J, --json                    : Output in JSON format instead of CSV
+                                     Produces a .json file conforming to json-schema.md
      -o, --org                     : Name of the GitHub Organization to be analyzed           
      -O, --output                  : Format of output, can either be "CSV" or "Table"
                                      Default: $OUTPUT
@@ -162,6 +165,10 @@ while (( "$#" )); do
     -o|--org)
       ORG_NAME=$2
       shift 2
+      ;;
+    -J|--json)
+      JSON_OUTPUT=1
+      shift
       ;;
     -rl|--repo-list)
       REPO_LIST_FILE=$2
@@ -321,7 +328,31 @@ Footer() {
   echo "######################################################"
   echo "The script has completed"
   echo ""
-  if [[ ${OUTPUT} != "CSV" ]]; then
+  if [[ ${JSON_OUTPUT} -eq 1 ]]; then
+    ################################
+    # Assemble final JSON output   #
+    ################################
+    REPO_FILE_COUNT=$(find "${JSON_TEMP_DIR}" -name 'repo-*.json' -type f | wc -l | tr -d ' ')
+    if [[ "${REPO_FILE_COUNT}" -gt 0 ]]; then
+      # Use find+sort+xargs to avoid ARG_MAX limits for large orgs
+      # Write to temp file first for atomic output (don't truncate existing file on failure)
+      JSON_TEMP_OUTPUT="${JSON_TEMP_DIR}/final-output.json"
+      find "${JSON_TEMP_DIR}" -name 'repo-*.json' -type f | sort | xargs cat | jq -s '{ repos: . }' > "${JSON_TEMP_OUTPUT}"
+      ERROR_CODE=$?
+      if [ "${ERROR_CODE}" -ne 0 ]; then
+        echo "ERROR! Failed to assemble final JSON file: ${JSON_FILE_NAME}"
+      else
+        mv "${JSON_TEMP_OUTPUT}" "${JSON_FILE_NAME}"
+        echo "Results file:[${JSON_FILE_NAME}]"
+      fi
+    else
+      # No repos found, write empty structure
+      echo '{ "repos": [] }' > "${JSON_FILE_NAME}"
+      echo "Results file:[${JSON_FILE_NAME}] (no repositories found)"
+    fi
+    # Clean up temp directory (also handled by trap, but be explicit)
+    rm -rf "${JSON_TEMP_DIR}"
+  elif [[ ${OUTPUT} != "CSV" ]]; then
     column -t -s','  "${OUTPUT_FILE_NAME}"
     rm -f "${OUTPUT_FILE_NAME}"
   else
@@ -339,30 +370,54 @@ GenerateFiles() {
   # Get datestring YYYYMMDDHHMM
   DATE=$(date +%Y%m%d%H%M)
 
+  ###############################
+  # Handle JSON output mode     #
+  ###############################
+  if [[ ${JSON_OUTPUT} -eq 1 ]]; then
+    JSON_FILE_NAME="$ORG_NAME-all_repos-$DATE.json"
+    JSON_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/gh-repo-stats-json.XXXXXX")
+    JSON_REPO_COUNTER=0
+
+    # Ensure temp directory is cleaned up on exit, interrupt, or termination
+    # shellcheck disable=SC2064
+    trap "rm -rf '${JSON_TEMP_DIR}'" EXIT INT TERM
+
+    ######################################################
+    # Need to see if there is a file that already exists #
+    ######################################################
+    EXISTING_JSON_CMD=$(find . -name "$ORG_NAME-all_repos-*.json" |grep . 2>&1)
+    ERROR_CODE=$?
+    if [ "${ERROR_CODE}" -eq 0 ]; then
+      JSON_FILE_NAME="${EXISTING_JSON_CMD:2}"
+    fi
+  fi
+
   ####################
   # Create File Name #
   ####################
   # Example: MyOrg-all_repos-201901041059.csv
-  OUTPUT_FILE_NAME="$ORG_NAME-all_repos-$DATE.csv"
+  if [[ ${JSON_OUTPUT} -ne 1 ]]; then
+    OUTPUT_FILE_NAME="$ORG_NAME-all_repos-$DATE.csv"
 
-  ######################################################
-  # Need to see if there is a file that already exists #
-  ######################################################
-  EXISTING_FILE_CMD=$(find . -name "$ORG_NAME-all_repos-*" |grep . 2>&1)
+    ######################################################
+    # Need to see if there is a file that already exists #
+    ######################################################
+    EXISTING_FILE_CMD=$(find . -name "$ORG_NAME-all_repos-*" |grep . 2>&1)
 
-  #######################
-  # Load the error code #
-  #######################
-  ERROR_CODE=$?
+    #######################
+    # Load the error code #
+    #######################
+    ERROR_CODE=$?
 
-  ##############################
-  # Check the shell for errors #
-  ##############################
-  if [ "${ERROR_CODE}" -eq 0 ]; then
-    # There is already file
-    # Going to use and append
-    OUTPUT_FILE_NAME="${EXISTING_FILE_CMD:2}"
-    EXISTING_FILE=1
+    ##############################
+    # Check the shell for errors #
+    ##############################
+    if [ "${ERROR_CODE}" -eq 0 ]; then
+      # There is already file
+      # Going to use and append
+      OUTPUT_FILE_NAME="${EXISTING_FILE_CMD:2}"
+      EXISTING_FILE=1
+    fi
   fi
 
   if [[ ${ANALYZE_CONFLICTS} -eq 1 ]]; then
@@ -426,7 +481,7 @@ GenerateFiles() {
   #########################################
   # Only add header if were not appending #
   #########################################
-  if [ "${EXISTING_FILE}" -ne 1 ]; then
+  if [[ ${JSON_OUTPUT} -ne 1 ]] && [ "${EXISTING_FILE}" -ne 1 ]; then
     #############################
     # Create Header in the file #
     #############################
@@ -828,25 +883,108 @@ ParseRepos() {
       #################################################################
       # Need to check if this repo has already been parsed in the doc #
       #################################################################
-      grep "${OWNER},${REPO_NAME}," "${OUTPUT_FILE_NAME}" >/dev/null 2>&1
-
-      #######################
-      # Load the error code #
-      #######################
-      ERROR_CODE=$?
-
-      ##############################
-      # Check the shell for errors #
-      ##############################
-      if [ ${ERROR_CODE} -eq 0 ]; then
-        # Found this in the csv already
-        echo "Repo:[${OWNER}/${REPO_NAME}] has previously been analyzed, moving on..."
-      elif [ ${ERROR_CODE} -ne 0 ] && [[ -z "${REPO_LIST_FILE}" ]]; then
+      if [[ ${JSON_OUTPUT} -eq 1 ]]; then
+        # In JSON mode, skip CSV de-dupe check and always parse
         echo "Analyzing Repo: ${REPO_NAME}"
         ParseRepoData "${REPO_DATA}"
+      else
+        grep "${OWNER},${REPO_NAME}," "${OUTPUT_FILE_NAME}" >/dev/null 2>&1
+
+        #######################
+        # Load the error code #
+        #######################
+        ERROR_CODE=$?
+
+        ##############################
+        # Check the shell for errors #
+        ##############################
+        if [ ${ERROR_CODE} -eq 0 ]; then
+          # Found this in the csv already
+          echo "Repo:[${OWNER}/${REPO_NAME}] has previously been analyzed, moving on..."
+        elif [ ${ERROR_CODE} -ne 0 ] && [[ -z "${REPO_LIST_FILE}" ]]; then
+          echo "Analyzing Repo: ${REPO_NAME}"
+          ParseRepoData "${REPO_DATA}"
+        fi
       fi
     fi
   done
+}
+################################################################################
+#### Function GenerateJSONObject ###############################################
+GenerateJSONObject() {
+  ########################################################
+  # Build a JSON object for this repo from existing data #
+  ########################################################
+  ((JSON_REPO_COUNTER++))
+
+  REPO_JSON=$(jq -n \
+    --arg org "$ORG_NAME" \
+    --arg name "$REPO_NAME" \
+    --arg url "$URL" \
+    --argjson isFork "$IS_FORK" \
+    --argjson isArchived "$IS_ARCHIVED" \
+    --argjson diskUsage "${REPO_SIZE_KB:-0}" \
+    --argjson sizeMB "${REPO_SIZE:-0}" \
+    --argjson hasWikiEnabled "$HAS_WIKI" \
+    --arg createdAt "$CREATED_AT" \
+    --arg updatedAt "$UPDATED_AT" \
+    --arg pushedAt "$PUSHED_AT" \
+    --argjson collaborators "${COLLABORATOR_CT:-0}" \
+    --argjson branches "${BRANCH_CT:-0}" \
+    --argjson tags "${TAG_CT:-0}" \
+    --argjson branchProtections "${PROTECTED_BRANCH_CT:-0}" \
+    --argjson issues "${ISSUE_CT:-0}" \
+    --argjson pullRequests "${PR_CT:-0}" \
+    --argjson milestones "${MILESTONE_CT:-0}" \
+    --argjson releases "${RELEASE_CT:-0}" \
+    --argjson projects "${PROJECT_CT:-0}" \
+    --argjson discussions "${DISCUSSION_CT:-0}" \
+    --argjson commitComments "${COMMIT_COMMENT_CT:-0}" \
+    --argjson issueEvents "${ISSUE_EVENT_CT:-0}" \
+    '{
+      org: $org,
+      name: $name,
+      url: $url,
+      isFork: $isFork,
+      isArchived: $isArchived,
+      diskUsage: $diskUsage,
+      sizeMB: $sizeMB,
+      hasWikiEnabled: $hasWikiEnabled,
+      createdAt: $createdAt,
+      updatedAt: $updatedAt,
+      pushedAt: $pushedAt,
+      collaborators: $collaborators,
+      branches: $branches,
+      tags: $tags,
+      branchProtections: $branchProtections,
+      issues: $issues,
+      pullRequests: $pullRequests,
+      milestones: $milestones,
+      releases: $releases,
+      projects: $projects,
+      discussions: $discussions,
+      commitComments: $commitComments,
+      issueEvents: $issueEvents
+    }')
+
+  ERROR_CODE=$?
+  if [ "${ERROR_CODE}" -ne 0 ]; then
+    echo "ERROR! Failed to generate JSON for repo: ${ORG_NAME}/${REPO_NAME}"
+    return 1
+  fi
+
+  ################################
+  # Write JSON to temp directory #
+  ################################
+  echo "${REPO_JSON}" > "${JSON_TEMP_DIR}/repo-$(printf '%06d' ${JSON_REPO_COUNTER}).json"
+
+  ERROR_CODE=$?
+  if [ "${ERROR_CODE}" -ne 0 ]; then
+    echo "ERROR! Failed to write JSON file for repo: ${ORG_NAME}/${REPO_NAME}"
+    return 1
+  fi
+
+  Debug "Generated JSON for repo: ${ORG_NAME}/${REPO_NAME}"
 }
 ################################################################################
 #### Function ParseRepoData ####################################################
@@ -930,20 +1068,24 @@ ParseRepoData() {
   ########################
   # Write it to the file #
   ########################
-  echo "${ORG_NAME},${REPO_NAME},${IS_EMPTY}${PUSHED_AT},${UPDATED_AT},${IS_FORK},${IS_ARCHIVED},${REPO_SIZE},${RECORD_CT},${COLLABORATOR_CT},${PROTECTED_BRANCH_CT},${PR_REVIEW_CT},${MILESTONE_CT},${ISSUE_CT},${PR_CT},${PR_REVIEW_COMMENT_CT},${COMMIT_COMMENT_CT},${ISSUE_COMMENT_CT},${ISSUE_EVENT_CT},${RELEASE_CT},${PROJECT_CT},${BRANCH_CT},${TAG_CT},${DISCUSSION_CT},${HAS_WIKI},${URL},${MIGRATION_ISSUE},${CREATED_AT}" >>"${OUTPUT_FILE_NAME}"
+  if [[ ${JSON_OUTPUT} -eq 1 ]]; then
+    GenerateJSONObject
+  else
+    echo "${ORG_NAME},${REPO_NAME},${IS_EMPTY}${PUSHED_AT},${UPDATED_AT},${IS_FORK},${IS_ARCHIVED},${REPO_SIZE},${RECORD_CT},${COLLABORATOR_CT},${PROTECTED_BRANCH_CT},${PR_REVIEW_CT},${MILESTONE_CT},${ISSUE_CT},${PR_CT},${PR_REVIEW_COMMENT_CT},${COMMIT_COMMENT_CT},${ISSUE_COMMENT_CT},${ISSUE_EVENT_CT},${RELEASE_CT},${PROJECT_CT},${BRANCH_CT},${TAG_CT},${DISCUSSION_CT},${HAS_WIKI},${URL},${MIGRATION_ISSUE},${CREATED_AT}" >>"${OUTPUT_FILE_NAME}"
 
-  #######################
-  # Load the error code #
-  #######################
-  # shellcheck disable=SC2320
-  ERROR_CODE=$?
+    #######################
+    # Load the error code #
+    #######################
+    # shellcheck disable=SC2320
+    ERROR_CODE=$?
 
-  ##############################
-  # Check the shell for errors #
-  ##############################
-  if [ "${ERROR_CODE}" -ne 0 ]; then
-    echo "ERROR! Failed to write output to file:[${OUTPUT_FILE_NAME}]"
-    exit 1
+    ##############################
+    # Check the shell for errors #
+    ##############################
+    if [ "${ERROR_CODE}" -ne 0 ]; then
+      echo "ERROR! Failed to write output to file:[${OUTPUT_FILE_NAME}]"
+      exit 1
+    fi
   fi
 
   ##############################

--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -976,10 +976,7 @@ GenerateJSONObject() {
   ################################
   # Write JSON to temp directory #
   ################################
-  echo "${REPO_JSON}" > "${JSON_TEMP_DIR}/repo-$(printf '%06d' ${JSON_REPO_COUNTER}).json"
-
-  ERROR_CODE=$?
-  if [ "${ERROR_CODE}" -ne 0 ]; then
+  if ! echo "${REPO_JSON}" > "${JSON_TEMP_DIR}/repo-$(printf '%06d' ${JSON_REPO_COUNTER}).json"; then
     echo "ERROR! Failed to write JSON file for repo: ${ORG_NAME}/${REPO_NAME}"
     return 1
   fi


### PR DESCRIPTION
This pull request adds support for JSON output to the `gh-repo-stats` tool, enabling users to export repository statistics in a structured JSON format that conforms to a newly defined schema. The changes include updates to the CLI, documentation, and the core script logic to generate and assemble JSON output, in addition to the existing CSV and table formats.

**JSON Output Support:**

* Added a `--json` (`-J`) flag to the CLI and updated the help text and usage examples in `README.md` and the script itself to document this new option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54) [[3]](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffR87-R88) [[4]](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffR169-R172)
* Implemented logic in `gh-repo-stats` to generate per-repository JSON files, aggregate them into a single JSON output conforming to a new schema, and clean up temporary files. [[1]](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffL324-R355) [[2]](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffR373-R399) [[3]](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffR421) [[4]](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffL429-R484) [[5]](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffR886-R890) [[6]](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffR909-R989) [[7]](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffR1071-R1073) [[8]](diffhunk://#diff-2b8d8a0d1e785e1290f27228283ae8e24fada656da8369aa652e39270de448ffR1089)

**Documentation and Schema:**

* Added `docs/json-schema.md` specifying the structure of the JSON output, including a detailed field list and an example. The schema matches the requirements for downstream tools such as `gh-stats-visualizer`.
* Updated the `README.md` to describe the new JSON output option, its schema, and usage, including a link to the schema documentation.

These changes make it easier to integrate `gh-repo-stats` with other tools and automate analysis by providing a well-documented, consistent JSON output format.