### PR TITLE
Fix Project_Count always reporting null

### DIFF
--- a/gh-repo-stats
+++ b/gh-repo-stats
@@ -1028,7 +1028,7 @@ ParseRepoData() {
   ISSUE_CT=$(_jq '.issues.totalCount')
   RELEASE_CT=$(_jq '.releases.totalCount')
   COMMIT_COMMENT_CT=$(_jq '.commitComments.totalCount')
-  PROJECT_CT=$(_jq '.projects.totalCount')
+  PROJECT_CT=$(_jq '.projectsV2.totalCount')
   BRANCH_CT=$(_jq '.branches.totalCount')
   TAG_CT=$(_jq '.tags.totalCount')
   DISCUSSION_CT=$(_jq '.discussions.totalCount')


### PR DESCRIPTION
### What

`Project_Count` (CSV) and `projects` (JSON) always report `null`, for every repository, in every organization.

### Why

#166 renamed the field in the GraphQL query from `projects` to `projectsV2`, but `ParseRepoData` was not updated and still reads the old path:

```bash
PROJECT_CT=$(_jq '.projects.totalCount')
```

`.projects` no longer exists in the response, so `jq` returns `null` and `PROJECT_CT` is set to the literal string `null`.

Same payload, both paths:

```console
$ gh api graphql -f query='{ repository(owner:"github",name:"docs"){ projectsV2{totalCount} } }' --jq '.data.repository'
{"projectsV2":{"totalCount":3}}

$ echo '{"projectsV2":{"totalCount":3}}' | jq -r '.projects.totalCount'     # current
null
$ echo '{"projectsV2":{"totalCount":3}}' | jq -r '.projectsV2.totalCount'   # fixed
3
```

### Impact

This surfaces in three places, not just the one column:

1. **CSV** — `Project_Count` prints `null`.

2. **JSON** — the `${PROJECT_CT:-0}` guard on the `--argjson` does *not* protect against this, because the variable is set to the non-empty string `null` rather than being unset:

   ```console
   $ PROJECT_CT="null"; echo "${PROJECT_CT:-0}"
   null
   ```

   So `--argjson projects null` emits `"projects": null`, which contradicts `docs/json-schema.md`, where `projects` is documented as `number`.

3. **`Record_Count`** — silently under-counted. Bash arithmetic treats the string `null` as an unset variable name and evaluates it to `0`, so projects never contribute to the total:

   ```console
   $ PROJECT_CT="null"; OTHER=5; echo $((OTHER + PROJECT_CT))
   5
   ```

   This one is easy to miss, since it fails quietly rather than erroring.

### The change

One line — point the parser at the field the query actually requests.

### Verification

Ran against a real org before and after.

Before (CSV / JSON):

```
Repo_Name                   Project_Count
agentic-devops-codeql-demo  null
sample-node-api             null
sample-python-service       null
```
```json
{ "name": "agentic-devops-codeql-demo", "projects": null, "issues": 1 }
```

After:

```
Repo_Name                   Project_Count
agentic-devops-codeql-demo  0
sample-node-api             0
sample-python-service       0
```
```json
{ "name": "agentic-devops-codeql-demo", "projects": 0, "issues": 1 }
```

Non-zero counts confirmed against `github/docs` (`projectsV2.totalCount = 3`) as shown above. `bash -n` passes; no other call sites reference `.projects`.

### Note on permissions

Reading `projectsV2` requires `read:project` on the token. That is already documented in the README as of #173, so no docs change is needed here — but it is worth being aware that without that scope the query errors out rather than returning `null`, which is a different failure mode from this bug.
