### PR TITLE
Correct the archived column name in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The permissions needed by `gh repo-stats` depends based on `-y, --token-type`:
 `gh repo-stats` produces either a visual table or `*.csv` file containing detailed information about various records within repositories. When the `--json` (`-J`) flag is provided, output is written as JSON conforming to the schema defined in [`json-schema.md`](docs/json-schema.md). The output conforms to the [gh-stats-visualizer](https://github.com/mona-actions/gh-stats-visualizer) input format.
 
 ```csv
-Org_Name,Repo_Name,Is_Empty,Last_Push,Last_Update,isFork,isArchive,Repo_Size(mb),Record_Count,Collaborator_Count,Protected_Branch_Count,PR_Review_Count,Milestone_Count,Issue_Count,PR_Count,PR_Review_Comment_Count,Commit_Comment_Count,Issue_Comment_Count,Issue_Event_Count,Release_Count,Project_Count,Branch_Count,Tag_Count,Discussion_Count,Has_Wiki,Full_URL,Migration_Issue,Created
+Org_Name,Repo_Name,Is_Empty,Last_Push,Last_Update,isFork,isArchived,Repo_Size(mb),Record_Count,Collaborator_Count,Protected_Branch_Count,PR_Review_Count,Milestone_Count,Issue_Count,PR_Count,PR_Review_Comment_Count,Commit_Comment_Count,Issue_Comment_Count,Issue_Event_Count,Release_Count,Project_Count,Branch_Count,Tag_Count,Discussion_Count,Has_Wiki,Full_URL,Migration_Issue,Created
 tinyfists,actions-experiments,false,2023-03-10T16:15:27Z,2022-10-28T19:38:34Z,false,false,0,19,18,0,0,0,0,1,0,0,0,0,0,0,2,0,0,true,https://github.com/tinyfists/actions-experiments,FALSE,2020-01-01T13:37:00Z
 tinyfists,git-xargs,false,2022-12-09T03:44:39Z,2022-11-01T03:19:49Z,false,false,0,19,18,0,0,0,0,1,0,0,0,0,0,0,2,0,0,true,https://github.com/tinyfists/git-xargs,FALSE,2020-01-01T13:37:00Z
 tinyfists,githubcustomer,false,2022-06-04T17:00:43Z,2022-05-10T03:05:16Z,false,false,0,25,18,0,0,0,4,0,0,0,0,3,0,0,1,0,0,true,https://github.com/tinyfists/githubcustomer,FALSE,2020-01-01T13:37:00Z
@@ -93,7 +93,7 @@ tinyfists,publish-packages-to-repo-demo,false,2022-12-09T03:43:31Z,2021-10-11T19
 - `Last_Push`: Date/time when a push was last made
 - `Last_Update`: Date/time when an update was last made
 - `isFork`: Whether the repository is a fork
-- `isArchive`: Whether the repository is archived
+- `isArchived`: Whether the repository is archived
 - `Repo_Size(mb)`: Size of the repository in megabytes
 - `Record_Count`: Number of database records this repository represents
 - `Collaborator_Count`: Number of users who have contributed to this repository


### PR DESCRIPTION
### What

The README documents the archived flag as `isArchive`, but the script emits `isArchived`.

```console
$ grep -o 'isFork,[a-zA-Z]*,Repo_Size' gh-repo-stats
isFork,isArchived,Repo_Size

$ grep -o 'isFork,[a-zA-Z]*,Repo_Size' README.md
isFork,isArchive,Repo_Size
```

Both the sample CSV block and the column list are affected, so anyone matching on the documented header name gets no match.

`docs/json-schema.md` already uses `isArchived`, so the README was the only inconsistent reference.

### Change

Two occurrences of the same word in `README.md`. No code, no behaviour change.

### How I noticed

I was diffing the README's documented header against real output field by field while working on something unrelated, and this was the only mismatch.
